### PR TITLE
fix error passing on emailVerificationFailed

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -54,10 +54,10 @@ const Action = {
     attributes,
   }),
 
-  emailVerificationFailed: (error, attributes) => ({
+  emailVerificationFailed: (user, error) => ({
     type: 'COGNITO_EMAIL_VERIFICATION_FAILED',
+    user,
     error,
-    attributes,
   }),
 
   beginPasswordResetFlow: (user, error) => ({


### PR DESCRIPTION
This fixes an issue where the 'invalid verification code' error message is not displayed