### PR TITLE
fix issue #1 -- examples don't build -- mkdir examples/htdocs/dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": "PWD=$(pwd) NODE_ENV=test mocha --debug-brk --inspect $npm_package_options_mocha",
     "test": "npm run lint && npm run testonly",
     "test-watch": "npm run testonly -- --watch --watch-extensions js",
-    "examples": "babel --plugins transform-es2015-modules-umd src --ignore __tests__ examples/src --out-file examples/htdocs/dist/bundle.js",
+    "examples": "[ -d examples/htdocs/dist ] || mkdir examples/htdocs/dist; babel --plugins transform-es2015-modules-umd src --ignore __tests__ examples/src --out-file examples/htdocs/dist/bundle.js",
     "doc": "esdoc",
     "prepublish": "webpack -p"
   },


### PR DESCRIPTION
Error: ENOENT: no such file or directory, open 'examples/htdocs/dist/bundle.js'

was because examples/htdocs/dist didn't exist.  

Alternatively that directory could just be created in git.