### PR TITLE
retain username post register

### DIFF
--- a/examples/src/LoginForm.jsx
+++ b/examples/src/LoginForm.jsx
@@ -5,6 +5,7 @@ class LoginForm extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      email: props.email,
       username: props.username,
       error: '',
       password: '',
@@ -28,6 +29,7 @@ class LoginForm extends React.Component {
   render = () => (
     <form onSubmit={this.onSubmit}>
       <div>{this.state.error}</div>
+      <div>{this.state.email}</div>
       <label>
         Username
         <input placeholder="Username" value={this.state.username} onChange={this.changeUsername} required />

--- a/examples/src/LoginForm.jsx
+++ b/examples/src/LoginForm.jsx
@@ -26,6 +26,10 @@ class LoginForm extends React.Component {
     this.setState({ password: event.target.value });
   }
 
+  componentWillUnmount = () => {
+    this.props.clearCache();
+  }
+
   render = () => (
     <form onSubmit={this.onSubmit}>
       <div>{this.state.error}</div>
@@ -44,8 +48,10 @@ class LoginForm extends React.Component {
 }
 LoginForm.propTypes = {
   onSubmit: PropTypes.func,
+  clearCache: PropTypes.func,
   username: PropTypes.string,
   error: PropTypes.string,
+  email: PropTypes.string,
 };
 
 export default LoginForm;

--- a/src/Confirm.jsx
+++ b/src/Confirm.jsx
@@ -17,7 +17,7 @@ const confirm = (verificationCode, user, dispatch) =>
         dispatch(Action.confirmFailed(user));
         reject(error.message);
       } else {
-        dispatch(Action.logout());
+        dispatch(Action.partialLogout());
         resolve(user);
       }
     });

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -10,7 +10,9 @@ const BaseLogin = props =>
 
 const mapStateToProps = (state) => {
   let username = '';
-  if (state.cognito.user) {
+  if (state.cognito.userName) {
+    username = state.cognito.userName;
+  } else if (state.cognito.user) {
     username = state.cognito.user.getUsername();
   }
   return {

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { authenticate } from './auth';
+import { Action } from './actions';
 
 const BaseLogin = props =>
   React.cloneElement(props.children, {
     username: props.username,
     email: props.email,
     onSubmit: props.onSubmit,
+    clearCache: props.clearCache,
   });
 
 const mapStateToProps = (state) => {
@@ -26,13 +28,15 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = dispatch => ({
   authenticator: (username, password, userPool, config) =>
-    authenticate(username, password, userPool, config, dispatch)
+    authenticate(username, password, userPool, config, dispatch),
+  clearCache: () => dispatch(Action.clearCache()),
 });
 
 const mergeProps = (stateProps, dispatchProps, ownProps) =>
   Object.assign({}, ownProps, stateProps, {
     onSubmit: (username, password) =>
       dispatchProps.authenticator(username, password, stateProps.userPool, stateProps.config),
+    clearCache: dispatchProps.clearCache,
   });
 
 /**

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -5,18 +5,20 @@ import { authenticate } from './auth';
 const BaseLogin = props =>
   React.cloneElement(props.children, {
     username: props.username,
+    email: props.email,
     onSubmit: props.onSubmit,
   });
 
 const mapStateToProps = (state) => {
   let username = '';
-  if (state.cognito.userName) {
-    username = state.cognito.userName;
-  } else if (state.cognito.user) {
+  if (state.cognito.user) {
     username = state.cognito.user.getUsername();
+  } else if (state.cognito.userName) {
+    username = state.cognito.cache.userName;
   }
   return {
     username,
+    email: state.cognito.cache.email,
     config: state.cognito.config,
     userPool: state.cognito.userPool,
   };

--- a/src/actions.js
+++ b/src/actions.js
@@ -27,6 +27,10 @@ const Action = {
     type: 'COGNITO_LOGOUT',
   }),
 
+  partialLogout: () => ({
+    type: 'COGNITO_PARTIAL_LOGOUT',
+  }),
+
   loginFailure: (user, error) => ({
     type: 'COGNITO_LOGIN_FAILURE',
     user,

--- a/src/actions.js
+++ b/src/actions.js
@@ -85,10 +85,10 @@ const Action = {
     attributes,
   }),
 
-  confirmationRequired: (user, error) => ({
+  confirmationRequired: (user, email) => ({
     type: 'COGNITO_USER_UNCONFIRMED',
     user,
-    error,
+    email,
   }),
 
   confirmFailed: (user, error) => ({

--- a/src/actions.js
+++ b/src/actions.js
@@ -96,6 +96,10 @@ const Action = {
     user,
     error,
   }),
+
+  clearCache: () => ({
+    type: 'COGNITO_CLEAR_CACHE',
+  }),
 };
 
 export { Action };

--- a/src/auth.js
+++ b/src/auth.js
@@ -113,7 +113,6 @@ const authenticate = (username, password, userPool, config, dispatch) =>
 
     user.authenticateUser(creds, {
       onSuccess: () => {
-        console.log('dispatching', dispatch);
         dispatch(Action.authenticated(user));
         resolve();
       },

--- a/src/auth.js
+++ b/src/auth.js
@@ -151,7 +151,7 @@ const registerUser = (userPool, config, username, password, attributes) =>
       if (err) {
         reject(err.message);
       } else if (result.userConfirmed === false) {
-        resolve(Action.confirmationRequired(result.user));
+        resolve(Action.confirmationRequired(result.user, attributes.email));
       } else {
         resolve(authenticate(username, password, userPool));
       }

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -5,7 +5,10 @@ import { CognitoState } from './states';
 
 const initial = {
   user: null,
-  userName: null, // cached for post register login
+  cache: { // cached for post register login
+    userName: null,
+    email: null,
+  },
   state: CognitoState.LOGGED_OUT,
   error: '',
   userPool: null,
@@ -120,7 +123,10 @@ export const cognito = (state = initial, action) => {
       return Object.assign({}, state, {
         user: action.user,
         state: CognitoState.CONFIRMATION_REQUIRED,
-        error: action.error,
+        cache: {
+          userName: action.user.username,
+          email: action.email
+        },
       });
 
     case 'COGNITO_USER_CONFIRM_FAILED':

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -5,6 +5,7 @@ import { CognitoState } from './states';
 
 const initial = {
   user: null,
+  userName: null, // cached for post register login
   state: CognitoState.LOGGED_OUT,
   error: '',
   userPool: null,
@@ -58,6 +59,7 @@ export const cognito = (state = initial, action) => {
     case 'COGNITO_AUTHENTICATED':
       return Object.assign({}, state, {
         user: action.user,
+        userName: null,
         error: '',
         state: CognitoState.AUTHENTICATED,
       });
@@ -78,6 +80,16 @@ export const cognito = (state = initial, action) => {
     case 'COGNITO_LOGOUT':
       return Object.assign({}, state, {
         user: null,
+        userName: null,
+        error: '',
+        creds: null,
+        state: CognitoState.LOGGED_OUT,
+      });
+
+    case 'COGNITO_PARTIAL_LOGOUT':
+      return Object.assign({}, state, {
+        user: null,
+        userName: state.user.username,
         error: '',
         creds: null,
         state: CognitoState.LOGGED_OUT,

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -86,10 +86,6 @@ export const cognito = (state = initial, action) => {
     case 'COGNITO_LOGOUT':
       return Object.assign({}, state, {
         user: null,
-        cache: {
-          userName: null,
-          email: null,
-        },
         error: '',
         creds: null,
         state: CognitoState.LOGGED_OUT,

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -70,6 +70,14 @@ export const cognito = (state = initial, action) => {
         state: CognitoState.AUTHENTICATED,
       });
 
+    case 'COGNITO_CLEAR_CACHE':
+      return Object.assign({}, state, {
+        cache: {
+          userName: null,
+          email: null,
+        },
+      });
+
     case 'COGNITO_LOGGING_IN':
       return Object.assign({}, state, {
         state: CognitoState.LOGGING_IN,

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -62,7 +62,10 @@ export const cognito = (state = initial, action) => {
     case 'COGNITO_AUTHENTICATED':
       return Object.assign({}, state, {
         user: action.user,
-        userName: null,
+        cache: {
+          userName: null,
+          email: null,
+        },
         error: '',
         state: CognitoState.AUTHENTICATED,
       });
@@ -83,7 +86,10 @@ export const cognito = (state = initial, action) => {
     case 'COGNITO_LOGOUT':
       return Object.assign({}, state, {
         user: null,
-        userName: null,
+        cache: {
+          userName: null,
+          email: null,
+        },
         error: '',
         creds: null,
         state: CognitoState.LOGGED_OUT,


### PR DESCRIPTION
This is so we can populate the sign in form with the username to make the user experience slightly better. 

There is a current issue logged with aws cognito to provide a mechanism for login after registration. The other option was to save the password too but I didn't want to do that. https://github.com/aws/amazon-cognito-identity-js/issues/186