### PR TITLE
Re-login after refresh from persisted local storage

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -18,10 +18,11 @@ const Action = {
     attributes,
   }),
 
-  login: (creds, groups) => ({
+  login: (creds, attributes, groups) => ({
     type: 'COGNITO_LOGIN',
     creds,
     groups,
+    attributes,
   }),
 
   logout: () => ({

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,7 +1,7 @@
 import { CognitoUser, AuthenticationDetails } from 'amazon-cognito-identity-js';
 import { CognitoIdentityCredentials } from 'aws-sdk';
 import { Action } from './actions';
-import { mkAttrList, sendAttributeVerificationCode } from './attributes';
+import { getUserAttributes, mkAttrList, sendAttributeVerificationCode } from './attributes';
 import { buildLogins, getGroups } from './utils';
 
 /**
@@ -66,7 +66,11 @@ const performLogin = (user, config, group) =>
 
           const username = user.getUsername();
           refreshIdentityCredentials(username, jwtToken, config).then(
-            creds => resolve(Action.login(creds, groups)),
+            (creds) => {
+              getUserAttributes(user).then((attributes) => {
+                resolve(Action.login(creds, attributes, groups));
+              });
+            },
             message => resolve(Action.loginFailure(user, message)));
         }
       });

--- a/src/auth.js
+++ b/src/auth.js
@@ -53,7 +53,9 @@ const refreshIdentityCredentials = (username, jwtToken, config) =>
 */
 const performLogin = (user, config, group) =>
   new Promise((resolve, reject) => {
-    if (user != null) {
+    if (user === null) {
+      resolve(Action.logout());
+    } else {
       user.getSession((err, session) => {
         if (err) {
           resolve(Action.loginFailure(user, err.message));
@@ -74,8 +76,6 @@ const performLogin = (user, config, group) =>
             message => resolve(Action.loginFailure(user, message)));
         }
       });
-    } else {
-      reject('user is null');
     }
   });
 

--- a/src/policy.js
+++ b/src/policy.js
@@ -81,6 +81,7 @@ const setupCognito = (store, config, listeners =
   listeners.forEach((f) => {
     enable(store, f, config.group);
   });
+  store.dispatch(Action.loggingIn({}));
 };
 
 export {


### PR DESCRIPTION
Browser refresh now reconstructs the login and user attributes from the information stored in local storage by the aws identity js.