### PR TITLE
React.PropTypes deprecated. Use prop-types package instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-dom": "~0.14.8 || ^15.0.0"
   },
   "dependencies": {
-    "babel-runtime": "^6.6.1"
+    "babel-runtime": "^6.6.1",
+    "prop-types": "^15.5.10"
   }
 }

--- a/src/Logout.jsx
+++ b/src/Logout.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types'
 import { Action } from './actions';
 
 /**
@@ -38,8 +39,8 @@ Logout.contextTypes = {
   store: PropTypes.object,
 };
 Logout.propTypes = {
-  children: React.PropTypes.any.isRequired,
-  onLogout: React.PropTypes.func,
+  children: PropTypes.any.isRequired,
+  onLogout: PropTypes.func,
 };
 Logout.defaultProps = {
   onLogout: () => {},


### PR DESCRIPTION
Using React.PropTypes is deprecated. Added `prop-types` package and fixed references to React.PropTypes. Fixes issue #24