### PR TITLE
clear error message when COGNITO_USER_UNCONFIRMED

### DIFF
--- a/src/reducers.js
+++ b/src/reducers.js
@@ -137,6 +137,7 @@ export const cognito = (state = initial, action) => {
     case 'COGNITO_USER_UNCONFIRMED':
       return Object.assign({}, state, {
         user: action.user,
+        error: '',
         state: CognitoState.CONFIRMATION_REQUIRED,
         cache: {
           userName: action.user.username,


### PR DESCRIPTION
Scenario:
1. try to login with wrong credentials. --> err message will appear
2. login with the good credentials --> move to COGNITO_USER_UNCONFIRMED state

The bad: error message, on confirm screen still display error from step 1

The fix: clear the error message