### PR TITLE
Fix BUG performLogin called multiple times

### DIFF
--- a/src/policy.js
+++ b/src/policy.js
@@ -10,10 +10,16 @@ import { CognitoState } from './states';
  * @param {function} f - f(state, dispatch)
 */
 const enable = (store, f, params) => {
+  let currentCognitoState;
+
   store.subscribe(() => {
     const state = store.getState();
     const dispatch = store.dispatch;
-    f(state, dispatch, params);
+      
+    if (state.cognito.state !== currentCognitoState) {
+      currentCognitoState = state.cognito.state;
+      f(state, dispatch, params);
+    }
   });
 };
 


### PR DESCRIPTION
Fix isotoma/react-cognito/issues/35

Since `enable` caused the policy function to be called for every action dispatched to the store, any action(s) dispatched between `state.cognito.state` transitions could caused duplicate calls of the policy function.

To fix this the store subscription handler checks if `state.cognito.state` has changed and only calls the policy function if it has.